### PR TITLE
Re-enable "buf breaking" check

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
-#      - uses: bufbuild/buf-breaking-action@v1.1.2
+      - uses: bufbuild/buf-breaking-action@v1.1.2
         with:
           against: buf.build/bufbuild/reflect
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
The [public BSR module](https://buf.build/bufbuild/reflect/activity/commit/bf8f65e8876c4811918f754f2488f292) has been sync'ed from the previous PR (#8), so we can now safely re-enable this CI check.